### PR TITLE
Removing the call to manipulate! improves Jpeg compression performance. ...

### DIFF
--- a/lib/carrierwave-imageoptimizer.rb
+++ b/lib/carrierwave-imageoptimizer.rb
@@ -4,10 +4,7 @@ require "carrierwave-imageoptimizer/version"
 module CarrierWave
   module ImageOptimizer
     def optimize
-      manipulate! do |img|
-        ::ImageOptimizer.new(current_path).optimize
-        img
-      end
+      ::ImageOptimizer.new(current_path).optimize
     end
   end
 end


### PR DESCRIPTION
... The writing back by rmagick of the image after the compression step caused an increase in image size:

```
  write_block = create_info_block(options[:write])
  if options[:format]
    frames.write("#{options[:format]}:#{current_path}", &write_block)
  else
    frames.write(current_path, &write_block)
  end
```

It seems like PNGs are unaffected by this change  This only improves Jpeg.
