### PR TITLE
Update jpegoptim url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tested against 1.9.3, 2.0.0, 2.1.0, ruby-head, jruby-19mode, jruby-head, rbx-2.1
 
 ##### This gem uses the following utilities for optimizing images:
 
-1. jpegoptim, which can be installed from [freecode.com](http://freecode.com/projects/jpegoptim)
+1. jpegoptim, which can be installed from the official [jpegoptim](https://github.com/tjko/jpegoptim) repository
 
 2. OptiPNG, which can be installed from [sourceforge.net](http://optipng.sourceforge.net/)
 


### PR DESCRIPTION
Hey :wave: 

I noticed that the link to install jpegoptim linked to freecode.com which is now in read only mode and as there was recently a new version of jpegoptim released the version referred to by the page is out of date.

I've changed the link to the official github repo which has the installation instructions in the README so I felt this is more appropriate for new users coming across this.

Hope this is ok.

Thanks,
.FxN