### PR TITLE
Carrierwave v2 compatibility

### DIFF
--- a/carrierwave-imageoptimizer.gemspec
+++ b/carrierwave-imageoptimizer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.signing_key   = File.expand_path('~/.ssh/gem-private_key.pem') if $0 =~ /gem\z/
   gem.cert_chain  = ['certs/jtescher.pem']
 
-  gem.add_dependency "carrierwave", [">= 0.8", "< 2.0"]
+  gem.add_dependency "carrierwave", [">= 0.8", "< 2.1"]
   gem.add_dependency "image_optimizer", ["~> 1.6"]
 
   gem.add_development_dependency "rspec",     "~> 2.14.1"


### PR DESCRIPTION
This PR closes this issue: https://github.com/jtescher/carrierwave-imageoptimizer/issues/31

```
Bundler could not find compatible versions for gem "carrierwave":
  In Gemfile:
    carrierwave (~> 2.0)

    carrierwave-imageoptimizer was resolved to 1.3.0, which depends on
      carrierwave (~> 0.8)
```


Original author of this fix is @jathayde

https://github.com/meticulous/carrierwave-imageoptimizer/commit/7a81de7462701ff93f0ce1bfd4cb3097f37feed0