### PR TITLE
Loosen version constraint to allow for CarrierWave 2.2 compatibility

### DIFF
--- a/carrierwave-imageoptimizer.gemspec
+++ b/carrierwave-imageoptimizer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.signing_key   = File.expand_path('~/.ssh/gem-private_key.pem') if $0 =~ /gem\z/
   gem.cert_chain  = ['certs/jtescher.pem']
 
-  gem.add_dependency "carrierwave", [">= 0.8", "< 2.2"]
+  gem.add_dependency "carrierwave", [">= 0.8", "< 3.0"]
   gem.add_dependency "image_optimizer", ["~> 1.6"]
 
   gem.add_development_dependency "rspec",     "~> 3.9.0"


### PR DESCRIPTION
Addresses #34. My thought is that by allowing for looser version constraints, this should allow for easier upgrading between CarrierWave minor versions (but this would still require more manual intervention before allowing compatibility with a major release).